### PR TITLE
added feature to enable using without defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-bsp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "An embassy-based boards support package (BSP) for BBC Micro:bit v2"
 license = "MIT OR Apache-2.0"
@@ -8,12 +8,19 @@ keywords = ["embedded", "async", "nordic", "nrf", "microbit"]
 categories = ["embedded", "hardware-support", "no-std", "asynchronous"]
 repository = "https://github.com/lulf/microbit-bsp"
 
+
+
 [dependencies]
-embassy-nrf = { version = "0.1.0", features = ["nrf52833", "gpiote", "time-driver-rtc1", "nfc-pins-as-gpio", "time", "defmt"]}
+embassy-nrf = { version = "0.1.0", features = ["nrf52833","gpiote","time-driver-rtc1","nfc-pins-as-gpio","time"]}
 embassy-time = { version = "0.3", default-features = false }
 embassy-sync = { version = "0.5", default-features = false }
 cortex-m = "0.7"
 embedded-hal = "1.0"
 lsm303agr = "0.3"
-defmt = "0.3"
 futures = { version = "0.3", default-features = false }
+defmt = { version = "0.3", optional = true }
+heapless = "0.8.0"
+
+[features]
+default = ["defmt"]
+defmt = ["dep:defmt", "embassy-nrf/defmt", "heapless/defmt-03"]

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ To run an example:
 cd examples/display
 cargo run --release
 ```
+## Cargo Features
+
+The feature `defmt` is enabled by default, and allows
+some crates to print things.


### PR DESCRIPTION
Currently this crate depends on `defmt`, and uses feature `embassy-nrf/defmt`. The dependency on `heapless` appears to be missing.

This PR adds the dependency on `heapless`, and adds a default `defmt` feature to this crate that depends on `defmt`, `embassy-nrf/defmt` and `heapless/defmt-03`.

As a result, this crate will not depend on `defmt` when built with `--no-default-features`.

I needed this to try switching from `defmt` to `rtt-target` on my crate. Unlike stock `defmt`, `rtt-target` works well with `cargo-embed`.