### PR TITLE
provide into_inner() for LedMatrix

### DIFF
--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -169,6 +169,12 @@ where
         }
         self.clear();
     }
+
+    /// Disassemble the `LedMatrix` and return the pins, as
+    /// an array of row pins and an array of column pins.
+    pub fn into_inner(self) -> ([P; ROWS], [P;COLS]) {
+        (self.pin_rows, self.pin_cols)
+    }
 }
 
 /// An effect filter to apply for an animation


### PR DESCRIPTION
`microbit-bsp` currently sets up the display as an `LedMatrix` at startup. This is very convenient. However, I needed the display pins for another thing.

This patch provides `LedMatrix::into_inner()`, which disassembles the matrix and returns its pins.