### PR TITLE
feat: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-bsp"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "An embassy-based boards support package (BSP) for BBC Micro:bit v2"
 license = "MIT OR Apache-2.0"
@@ -9,14 +9,13 @@ categories = ["embedded", "hardware-support", "no-std", "asynchronous"]
 repository = "https://github.com/lulf/microbit-bsp"
 
 
-
 [dependencies]
-embassy-nrf = { version = "0.1.0", features = ["nrf52833","gpiote","time-driver-rtc1","nfc-pins-as-gpio","time"]}
+embassy-nrf = { version = "0.2.0", features = ["nrf52833","gpiote","time-driver-rtc1","nfc-pins-as-gpio","time"] }
 embassy-time = { version = "0.3", default-features = false }
-embassy-sync = { version = "0.5", default-features = false }
+embassy-sync = { version = "0.6", default-features = false }
 cortex-m = "0.7"
 embedded-hal = "1.0"
-lsm303agr = "0.3"
+lsm303agr = "1.1.0"
 futures = { version = "0.3", default-features = false }
 defmt = { version = "0.3", optional = true }
 heapless = "0.8.0"

--- a/examples/accelerometer/Cargo.toml
+++ b/examples/accelerometer/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-microbit-bsp= { path = "../../" }
+microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1", default-features = false }
-embassy-executor = { version = "0.5", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
+embassy-executor = { version = "0.6", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
 embassy-time = { version = "0.3", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"

--- a/examples/ble/Cargo.toml
+++ b/examples/ble/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-microbit-bsp= { path = "../../" }
+microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1", default-features = false }
-embassy-executor = { version = "0.5", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "task-arena-size-32768"] }
+embassy-executor = { version = "0.6", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "task-arena-size-32768"] }
 embassy-time = { version = "0.3", default-features = false, features = ["defmt-timestamp-uptime"] }
 
 nrf-softdevice = { version = "0.1.0", features = ["ble-peripheral", "ble-gatt-server", "s113", "nrf52833", "critical-section-impl", "defmt"] }
 nrf-softdevice-s113 = { version = "0.1.0" }
 
-heapless = "0.7"
+heapless = "0.8"
 cortex-m-rt = "0.7"
-static_cell = "1"
+static_cell = "2"
 
 defmt = "0.3"
 defmt-rtt = "0.4"

--- a/examples/ble/README.md
+++ b/examples/ble/README.md
@@ -7,8 +7,7 @@ Demonstrating the use of Bluetooth Low Energy (BLE) on the BBC micro:bit.
 Software:
 
 * [`rustup`](https://rustup.rs/)
-* [`probe-run`](https://github.com/knurling-rs/probe-run)
-* [`probe-rs-cli`](https://github.com/probe-rs/probe-rs)
+* [`probe-rs`](https://github.com/probe-rs/probe-rs)
 
 Hardware:
 
@@ -21,7 +20,7 @@ Download the [softdevice](https://www.nordicsemi.com/Products/Development-softwa
 Flash the softdevice onto the micro:bit (only needed the first time you run it):
 
 ```
-probe-rs-cli download s113_nrf52_7.3.0_softdevice.hex --format Hex --chip nRF52833_xxAA
+probe-rs download s113_nrf52_7.3.0_softdevice.hex --binary-format Hex --chip nRF52833_xxAA
 ```
 
 Run the application:

--- a/examples/display/Cargo.toml
+++ b/examples/display/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-microbit-bsp= { path = "../../" }
+microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1", default-features = false }
-embassy-executor = { version = "0.5", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
+embassy-executor = { version = "0.6", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
 embassy-time = { version = "0.3", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"

--- a/examples/speaker/Cargo.toml
+++ b/examples/speaker/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-microbit-bsp= { path = "../../" }
+microbit-bsp = { path = "../../" }
 
 embassy-futures = { version = "0.1", default-features = false }
-embassy-executor = { version = "0.5", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
+embassy-executor = { version = "0.6", default-features = false, features = ["integrated-timers", "defmt", "arch-cortex-m", "executor-thread", "executor-interrupt", "task-arena-size-32768"] }
 embassy-time = { version = "0.3", default-features = false, features = ["defmt-timestamp-uptime", "defmt"] }
 
 cortex-m-rt = "0.7"

--- a/src/accelerometer/mod.rs
+++ b/src/accelerometer/mod.rs
@@ -7,13 +7,13 @@ use embassy_sync::channel::DynamicSender;
 use embassy_time::{Duration, Ticker};
 use lsm303agr::interface::I2cInterface;
 use lsm303agr::mode::MagOneShot;
-use lsm303agr::{AccelMode, Error as LsmError, Lsm303agr, Status, Acceleration};
-pub use lsm303agr::{AccelOutputDataRate};
+use lsm303agr::{AccelMode, Acceleration, Error as LsmError, Lsm303agr, Status};
+pub use lsm303agr::AccelOutputDataRate;
 
 type I2C<'d> = twim::Twim<'d, TWISPI0>;
 
 /// Accelerometer error
-pub type Error = LsmError<twim::Error, ()>;
+pub type Error = LsmError<twim::Error>;
 
 /// Accelerometer peripheral present on the microbit
 pub struct Accelerometer<'d> {

--- a/src/board.rs
+++ b/src/board.rs
@@ -10,10 +10,10 @@ pub use embassy_nrf::wdt;
 use crate::display::LedMatrix as LedMatrixDriver;
 
 /// LED matrix peripheral for the micro:bit
-pub type LedMatrix = LedMatrixDriver<Output<'static, AnyPin>, 5, 5>;
+pub type LedMatrix = LedMatrixDriver<Output<'static>, 5, 5>;
 
 /// Button 'A'
-pub type Button = Input<'static, AnyPin>;
+pub type Button = Input<'static>;
 
 /// Represents all the peripherals and pins available for the BBC micro:bit.
 pub struct Microbit {
@@ -152,6 +152,6 @@ impl Microbit {
     }
 }
 
-fn output_pin(pin: AnyPin) -> Output<'static, AnyPin> {
+fn output_pin(pin: AnyPin) -> Output<'static> {
     Output::new(pin, Level::Low, OutputDrive::Standard)
 }

--- a/src/mic.rs
+++ b/src/mic.rs
@@ -9,7 +9,7 @@ use embassy_time::{Duration, Timer};
 /// Microphone interface
 pub struct Microphone<'a> {
     adc: Saadc<'a, 1>,
-    enable: Output<'a, P0_20>,
+    enable: Output<'a>,
 }
 
 impl<'a> Microphone<'a> {


### PR DESCRIPTION
This PR just updates some of the dependency versions, with the main goal being to catch the recent(ish) embassy release. The changes to embassy-nrf appear to be semver breaking, so the minor version was bumped as well. All examples were tested & confirmed to still work.