### PR TITLE
fix: embassy-nrf features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-bsp"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "An embassy-based boards support package (BSP) for BBC Micro:bit v2"
 license = "MIT OR Apache-2.0"
@@ -11,11 +11,12 @@ rust-version = "1.83"
 
 
 [dependencies]
-embassy-nrf = { version = "0.3", default-features = false, features = [
+embassy-nrf = { version = "0.3", features = [
     "gpiote",
     "nfc-pins-as-gpio",
     "nrf52833",
     "time-driver-rtc1",
+    "time",
 ] }
 embassy-time = { version = "0.4", default-features = false }
 embassy-sync = { version = "0.6.2" }

--- a/examples/ble/Cargo.toml
+++ b/examples/ble/Cargo.toml
@@ -30,5 +30,5 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 debug = 2
 
 [patch.crates-io]
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "b193eaa1718aeadd3b5eca54f1784aeceba75385" }
-nrf-softdevice-s113 = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "b193eaa1718aeadd3b5eca54f1784aeceba75385" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "7e017eb3dba5bac30748916012b886214291c132" }
+nrf-softdevice-s113 = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "7e017eb3dba5bac30748916012b886214291c132" }


### PR DESCRIPTION
**Issue**
Fixes #20

**Description of changes**
Removal of default features from `embassy-nrf` drops the `rt` feature, which is required for the interrupt handlers within the `gpiote` and `time-driver` modules to be included in the build.

Also added back the `time` feature, which is used within various blocking TWI APIs, and within `nfct`.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._