### PR TITLE
chore: update example dependencies

### DIFF
--- a/examples/accelerometer/Cargo.toml
+++ b/examples/accelerometer/Cargo.toml
@@ -19,9 +19,9 @@ embassy-time = { version = "0.4", default-features = false, features = ["defmt-t
 cortex-m-rt = "0.7"
 
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
-defmt = "0.3.10"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1.0.1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 [profile.release]
 debug = 2

--- a/examples/ble-nrf-softdevice/Cargo.toml
+++ b/examples/ble-nrf-softdevice/Cargo.toml
@@ -22,9 +22,9 @@ heapless = "0.8"
 cortex-m-rt = "0.7"
 static_cell = "2"
 
-defmt = "0.3.10"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1.0.1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 [profile.release]
 debug = 2

--- a/examples/ble-trouble/Cargo.toml
+++ b/examples/ble-trouble/Cargo.toml
@@ -20,16 +20,13 @@ microbit-bsp = { path = "../../", features = ["trouble"]}
 futures = { version = "0.3", default-features = false, features = ["async-await"]}
 trouble-host = { version = "0.1.0", features = ["defmt", "gatt", "peripheral"] }
 
-defmt = "0.3.10"
-defmt-rtt = "0.4.0"
+defmt = "1.0.1"
+defmt-rtt = "1"
 
 cortex-m = { version = "0.7.6" }
 cortex-m-rt = "0.7.5"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+panic-probe = { version = "1", features = ["print-defmt"] }
 static_cell = "2"
 
 [profile.release]
 debug = 2
-
-[patch.crates-io]
-trouble-host = { version = "0.1.0", git = "https://github.com/embassy-rs/trouble.git", rev = "7700932050221fa68a274fe713f7d1eb3d477ea2" }

--- a/examples/display/Cargo.toml
+++ b/examples/display/Cargo.toml
@@ -19,9 +19,9 @@ embassy-time = { version = "0.4.0", default-features = false, features = ["defmt
 cortex-m-rt = "0.7"
 
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
-defmt = "0.3.10"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1.0.1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 [profile.release]
 debug = 2

--- a/examples/speaker/Cargo.toml
+++ b/examples/speaker/Cargo.toml
@@ -19,9 +19,9 @@ embassy-time = { version = "0.4", default-features = false, features = ["defmt-t
 cortex-m-rt = "0.7"
 
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
-defmt = "0.3.10"
-defmt-rtt = "0.4"
-panic-probe = { version = "0.3", features = ["print-defmt"] }
+defmt = "1.0.1"
+defmt-rtt = "1"
+panic-probe = { version = "1", features = ["print-defmt"] }
 
 [profile.release]
 debug = 2


### PR DESCRIPTION
This is mostly to update the `ble-trouble` example to work with the version released on crates.io, but also threw in the token `defmt` v1 update as well.