### PR TITLE
chore: update version to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-bsp"
-version = "0.6.0"
+version = "0.4.0"
 edition = "2021"
 description = "An embassy-based boards support package (BSP) for BBC Micro:bit v2"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Current crates.io version is 0.3, next up is 0.4